### PR TITLE
fix copying contents in /usr/local/lib and cleanup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 
 # paths
-dirname=$(dirname $0)
+dirname=$(pwd)
 lib="/usr/local/lib"
 bin="/usr/local/bin"
 


### PR DESCRIPTION
I realized that with `$(dirname $0)` the `cp` command copies the entire content of the `dots` folder rather than the `dots` folder itself, messing up `/usr/local/lib`.
